### PR TITLE
Add JetBrain's DataGrip/IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ A curated list of delightful Tarantool [modules](#modules),
   web-based user interface.
 - [ocelotgui](https://github.com/ocelot-inc/ocelotgui-tarantool) -
   primarily for Tarantool/SQL.
+- [DataGrip](https://www.jetbrains.com/datagrip/) or [IntelliJ
+  IDEA](https://www.jetbrains.com/idea/) with [Tarantool Database
+  plugin](https://plugins.jetbrains.com/plugin/17422-tarantool-database) -
+  cross platform database IDE that can do SQL queries.
 
 ### System
 


### PR DESCRIPTION
I think this one the best IDE for Tarantool for now.
![image](https://user-images.githubusercontent.com/1061610/131131652-f239cb0c-69d6-4d9d-ba87-1021cc64f010.png)
